### PR TITLE
Fix artifact version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The library is available as a maven package:
 <dependency>
     <groupId>me.bechberger</groupId>
     <artifactId>bpf</artifactId>
-    <version>0.1.1-scx-enabled-SNAPSHOT</version>
+    <version>0.1.1-scx-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The mvn version currently mentioned in README.md (`0.1.1-scx-enabled-SNAPSHOT`) does not exist in the repository but [`0.1.1-scx-SNAPSHOT`](https://s01.oss.sonatype.org/content/repositories/snapshots/me/bechberger/bpf/0.1.1-scx-SNAPSHOT/) does