### PR TITLE
Add `bpf_` prefix to `@BPFFunctionAlternative` of `pop` 

### DIFF
--- a/bpf/src/main/java/me/bechberger/ebpf/bpf/map/BPFQueueAndStack.java
+++ b/bpf/src/main/java/me/bechberger/ebpf/bpf/map/BPFQueueAndStack.java
@@ -87,7 +87,7 @@ public abstract class BPFQueueAndStack<V> extends BPFMap {
      *
      * @return the value, or null if the stack/queue is empty
      */
-    @BPFFunctionAlternative("pop")
+    @BPFFunctionAlternative("bpf_pop")
     public @Nullable V pop() {
         try (var arena = Arena.ofConfined()) {
             var valueSegment = valueType.allocate(arena);


### PR DESCRIPTION
`@BPFFunctionAlternative` for `pop` was missing its `bpf_` prefix resulting in a very helpful
> Method pop cannot be used, please use pop instead

error message :D