### PR TITLE
Add a property to control scheduler timeout

### DIFF
--- a/bpf-samples/src/main/java/me/bechberger/ebpf/samples/MinimalScheduler.java
+++ b/bpf-samples/src/main/java/me/bechberger/ebpf/samples/MinimalScheduler.java
@@ -14,6 +14,7 @@ import static me.bechberger.ebpf.runtime.TaskDefinitions.task_struct;
 
 @BPF(license = "GPL")
 @Property(name = "sched_name", value = "minimal_scheduler")
+@Property(name = "timeout_ms", value = "10000")
 public abstract class MinimalScheduler extends BPFProgram implements Scheduler {
 
     private static final int SHARED_DSQ_ID = 0;

--- a/bpf/src/main/java/me/bechberger/ebpf/bpf/Scheduler.java
+++ b/bpf/src/main/java/me/bechberger/ebpf/bpf/Scheduler.java
@@ -133,11 +133,13 @@ import java.util.function.Consumer;
                 	       .dequeue         = (void *)simple_dequeue,
                 	       .tick            = (void *)simple_tick,
                 	       .flags			= SCX_OPS_ENQ_LAST | SCX_OPS_KEEP_BUILTIN_IDLE,
+                	       .timeout_ms      = __property_timeout_ms,
                 	       .name			= "__property_sched_name");
                 """
 )
 @Requires(sched_ext = true)
 @PropertyDefinition(name = "sched_name", defaultValue = "hello", regexp = "[a-zA-Z0-9_]+")
+@PropertyDefinition(name = "timeout_ms", defaultValue = "30000", regexp = "[1-9]\\d*")
 public interface Scheduler {
 
     /** No such process error code */

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/SchedulerTimeoutTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/SchedulerTimeoutTest.java
@@ -1,0 +1,54 @@
+package me.bechberger.ebpf.bpf;
+
+import me.bechberger.ebpf.annotations.Unsigned;
+import me.bechberger.ebpf.annotations.bpf.BPF;
+import me.bechberger.ebpf.annotations.bpf.Property;
+import me.bechberger.ebpf.runtime.TaskDefinitions;
+import me.bechberger.ebpf.shared.TraceLog;
+import me.bechberger.ebpf.type.Ptr;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static me.bechberger.ebpf.runtime.ScxDefinitions.*;
+import static me.bechberger.ebpf.runtime.helpers.BPFHelpers.bpf_strncmp;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SchedulerTimeoutTest {
+    private static final String NO_SCHEDULE_NAME = "NO_SCHED";
+
+    @BPF(license = "GPL")
+    @Property(name = "sched_name", value = "timeout_test")
+    @Property(name = "timeout_ms", value = "3000")
+    public abstract static class ThreeSecondScheduler extends BPFProgram implements Scheduler {
+
+        @Override
+        public void enqueue(Ptr<TaskDefinitions.task_struct> p, long enq_flags) {
+            if (bpf_strncmp(Ptr.of(p.val().comm).asString(), 16, NO_SCHEDULE_NAME) != 0) {
+                @Unsigned int queueCount = scx_bpf_dsq_nr_queued(scx_dsq_id_flags.SCX_DSQ_GLOBAL.value());
+                scx_bpf_dispatch(p, scx_dsq_id_flags.SCX_DSQ_GLOBAL.value(), 5_000_000 / queueCount, enq_flags);
+            }
+        }
+    }
+
+    @Test
+    public void testThreeSecondTimeout() throws InterruptedException {
+        try (var program = BPFProgram.load(ThreeSecondScheduler.class)) {
+            var noScheduleThread = new Thread(() -> {
+                while (true) {}
+            });
+            noScheduleThread.setName(NO_SCHEDULE_NAME);
+
+            program.attachScheduler();
+            noScheduleThread.start();
+
+            Thread.sleep(2000);
+            assertTrue(program.isSchedulerAttachedProperly());
+            Thread.sleep(2000);
+            assertFalse(program.isSchedulerAttachedProperly());
+
+            TraceLog.getInstance().readAllAvailableLines(Duration.ofMillis(100));
+        }
+    }
+}


### PR DESCRIPTION
This defines a `timeout_ms` property that controls the `.timeout_ms` field of the scheduler `SCX_OPS`.
To support this, the property collection code in the compiler plugin has been fixed to always fallback to the default value. Previously this was only done when *none* of the properties were specified.