### PR TITLE
Fix runtime default property resolution

### DIFF
--- a/bpf/src/main/java/me/bechberger/ebpf/bpf/BPFProgram.java
+++ b/bpf/src/main/java/me/bechberger/ebpf/bpf/BPFProgram.java
@@ -845,7 +845,7 @@ public abstract class BPFProgram implements AutoCloseable {
             if (prop != null && prop.name().equals(name)) {
                 return prop.defaultValue();
             }
-            queue.addAll(Arrays.asList(clazz.getInterfaces()));
+            queue.addAll(Arrays.asList(clazz.getSuperclass().getInterfaces()));
         }
         return null;
     }


### PR DESCRIPTION
To get the default value for a property at runtime, `getDefaultPropertyValue` checks the interfaces of the calling class. Since the calling class is the generated `*Impl` class, the correct class to check is the superclass of the current class.