### PR TITLE
Fix build errors and failing tests

### DIFF
--- a/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/CompilerPlugin.java
+++ b/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/CompilerPlugin.java
@@ -686,7 +686,7 @@ public class CompilerPlugin implements Plugin {
             return;
         }
 
-        code = implAnn.before() + "\n\n" + code;
+        code = implAnn.before() + code;
 
         var properties = getAllPropertyValues(programPath, superClassElement);
 

--- a/bpf-samples/src/main/java/me/bechberger/ebpf/samples/MinimalScheduler.java
+++ b/bpf-samples/src/main/java/me/bechberger/ebpf/samples/MinimalScheduler.java
@@ -2,6 +2,7 @@
 
 package me.bechberger.ebpf.samples;
 
+import me.bechberger.ebpf.annotations.Unsigned;
 import me.bechberger.ebpf.annotations.bpf.BPF;
 import me.bechberger.ebpf.annotations.bpf.Property;
 import me.bechberger.ebpf.bpf.BPFProgram;
@@ -25,7 +26,7 @@ public abstract class MinimalScheduler extends BPFProgram implements Scheduler {
 
     @Override
     public void enqueue(Ptr<task_struct> p, long enq_flags) {
-        scx_bpf_dispatch(p, SHARED_DSQ_ID,  5_000_000 /
+        scx_bpf_dispatch(p, SHARED_DSQ_ID,  ((@Unsigned int) 5_000_000) /
                 scx_bpf_dsq_nr_queued(SHARED_DSQ_ID), enq_flags);
     }
 

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
@@ -4,6 +4,8 @@ import me.bechberger.ebpf.annotations.bpf.BPF;
 import me.bechberger.ebpf.shared.TraceLog;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,28 +19,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FEntryExitAutoAttachTest {
 
     @BPF(license = "GPL")
-    public static abstract class UnlinkAt extends BPFProgram {
+    public static abstract class OpenAt extends BPFProgram {
+
+        final GlobalVariable<Integer> targetPid = new GlobalVariable<>(0);
+        private static final String SYS_PREFIX = "/sys/";
 
         static final String EBPF_PROGRAM = """
                 #include "vmlinux.h"
                 #include <bpf/bpf_helpers.h>
                 #include <bpf/bpf_tracing.h>
                 
-                SEC("fentry/do_unlinkat")
-                int BPF_PROG(do_unlinkat, int dfd, struct filename *name)
+                SEC("fentry/do_sys_openat2")
+                int BPF_PROG(do_openat2, long dfd, const u8* name, struct open_how *how)
                 {
+                	char name_copy[sizeof(SYS_PREFIX)];
+                	BPF_SNPRINTF(name_copy, sizeof(name_copy), "%s", name);
+                	bool is_sys = bpf_strncmp(name_copy, sizeof(SYS_PREFIX), (const u8*) SYS_PREFIX) == 0;
                 	pid_t pid;
                 	pid = bpf_get_current_pid_tgid() >> 32;
-                	bpf_printk("fentry: pid = %d, filename = %s\\n", pid, name->name);
+                	if (pid == targetPid && !is_sys) {
+                	    bpf_printk("fentry: pid = %d, filename = %s", pid, name);
+                	}
                 	return 0;
                 }
                 
-                SEC("fexit/do_unlinkat")
-                int BPF_PROG(do_unlinkat_exit, int dfd, struct filename *name, long ret)
+                SEC("fexit/do_sys_openat2")
+                int BPF_PROG(do_openat2_exit, long dfd, const char *name, struct open_how *how, long ret)
                 {
+                	char name_copy[sizeof(SYS_PREFIX)];
+                	BPF_SNPRINTF(name_copy, sizeof(name_copy), "%s", name);
+                	bool is_sys = bpf_strncmp(name_copy, sizeof(SYS_PREFIX), (const u8*) SYS_PREFIX) == 0;
                 	pid_t pid;
                 	pid = bpf_get_current_pid_tgid() >> 32;
-                	bpf_printk("fexit: pid = %d, filename = %s, ret = %ld\\n", pid, name->name, ret);
+                	if (pid == targetPid && !is_sys) {
+                	    bpf_printk("fexit: pid = %d, filename = %s", pid, name);
+                	}
                 	return 0;
                 }
                 
@@ -51,19 +66,27 @@ public class FEntryExitAutoAttachTest {
     }
 
     @Test
-    public void testUnlinkAt() {
-        try (var program = BPFProgram.load(UnlinkAt.class).autoAttachPrograms()) {
-            var testFile = TestUtil.triggerOpenAt();
-            var line = program.readTraceFields();
-            assertTrue(line.msg().contains(testFile.toString()));
-            TraceLog.getInstance().readAllAvailableLines();
+    public void testOpenAt() throws IOException {
+        Path testFile;
+        try (var program = BPFProgram.load(OpenAt.class)) {
+            program.autoAttachPrograms();
+            program.targetPid.set((int) ProcessHandle.current().pid());
+            testFile = TestUtil.triggerOpenAt();
         }
+        var entryLine = TraceLog.getInstance().readLine();
+        assertTrue(entryLine.contains("fentry"), entryLine);
+        assertTrue(entryLine.contains(testFile.toString()), entryLine);
+        var exitLine = TraceLog.getInstance().readLine();
+        assertTrue(exitLine.contains("fexit"), exitLine);
+        assertTrue(exitLine.contains(testFile.toString()), exitLine);
+
+        var line = TraceLog.getInstance().readAllAvailableLines();
     }
 
     @Test
     public void testAutoAttachAll() {
-        try (var program = BPFProgram.load(UnlinkAt.class)) {
-            assertEquals(List.of("do_unlinkat", "do_unlinkat_exit", "kprobe__do_sys_openat2"), program.getAutoAttachablePrograms());
+        try (var program = BPFProgram.load(OpenAt.class)) {
+            assertEquals(List.of("do_openat2", "do_openat2_exit", "kprobe__do_sys_openat2"), program.getAutoAttachablePrograms());
         }
     }
 }

--- a/shared/src/main/java/me/bechberger/ebpf/shared/TraceLog.java
+++ b/shared/src/main/java/me/bechberger/ebpf/shared/TraceLog.java
@@ -197,12 +197,12 @@ public class TraceLog {
     public List<String> readAllAvailableLines(Duration waitAtMost) {
         List<String> lines = new ArrayList<>();
         long start = System.nanoTime();
-        while (Duration.ofNanos(System.nanoTime() - start).compareTo(waitAtMost) < 0) {
+        do {
             while (traceFile.ready()) {
                 lines.add(traceFile.readLine());
                 start = System.nanoTime();
             }
-        }
+        } while (Duration.ofNanos(System.nanoTime() - start).compareTo(waitAtMost) < 0);
         return lines;
     }
 }

--- a/shared/src/main/java/me/bechberger/ebpf/shared/util/LineReader.java
+++ b/shared/src/main/java/me/bechberger/ebpf/shared/util/LineReader.java
@@ -69,7 +69,7 @@ public class LineReader {
      */
     public boolean ready() {
         try {
-            return reader.ready() && input.available() > 0;
+            return reader.ready();
         } catch (IOException e) {
             return false;
         }


### PR DESCRIPTION
This fixes one clang compilation error in the MinimalScheduler sample and the two currently failing tests:
- Add `@Unsigned` annotation to division in MinimalScheduler sample
- Remove two extra newlines in `CompilerPlugin.java`, this previously caused `TypeProcessingTest#testIncludesAndInterface` to fail because of the extra newlines between `x` and `y`
- `FEntryExitAutoAttachTest`:
  - Change the used syscall to `openat2` since this is what is triggered by `TestUtil`
  - Don't trace syscalls from other processes or with `/sys/*` files
  - Remove `input.available() > 0` condition from `LineReader.ready()`. The trace pipe is not seekable, causing this condition to alway throw an exception, preventing LineReader from ever getting ready.
  - Change `readAllAvailableLines` to a do while-loop.

I'm not totally happy with the trace changes to `FEntryExitAutoAttachTest`, but the `ready()` behaviour of `TraceLog`/the underlying `BufferedReader` isn't great. For example, it often seems to require a blocking `read()` to report as ready. In some cases, this causes traces from one test to leak another one, which isn't ideal.
A solution with GlobalVariables or a ring buffer would probably be better (for all tests).