### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-19 libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
 
       - name: mvn package
         run: ./mvnw -ntp -B package -DskipTests
@@ -44,7 +44,7 @@ jobs:
   vm-test:
     if: false
     name: Run tests on pre-built kernel
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -69,7 +69,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-19 libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
 
       - name: Build
         run: ./mvnw -Ppublication -ntp -B --file pom.xml verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-19 libbpf-dev linux-tools-common linux-tools-$(uname -r) gcc-multilib
 
       - name: Build
         run: ./mvnw -ntp -B --file pom.xml verify


### PR DESCRIPTION
The ci build is currently failing because of the `gnu2y` clang flag, that requires clang >=19. Installing clang-19 (with ubuntu-24.04) revealed some very weird logic to find the newest clang version.
With that addressed, the ci now runs [cleanly](https://github.com/Mr-Pine/hello-ebpf/actions/runs/13399057338).

Fixes #41 