### PR TITLE
Move tests to RingBuffers and GlobalVariables

### DIFF
--- a/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/MethodHeaderTemplate.java
+++ b/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/MethodHeaderTemplate.java
@@ -110,7 +110,7 @@ public record MethodHeaderTemplate(String raw, List<TemplatePart> parts) {
                 part = part.substring(6);
             } else if (part.startsWith("params")) {
                 templateParts.add(new TemplatePart.Params());
-                part = part.substring(5);
+                part = part.substring(6);
             } else {
                 // split at first char that is neither number nor char
                 int j = 0;

--- a/bpf-processor/src/main/java/me/bechberger/ebpf/type/BPFType.java
+++ b/bpf-processor/src/main/java/me/bechberger/ebpf/type/BPFType.java
@@ -1076,7 +1076,7 @@ public sealed interface BPFType<T> {
         @Override
         public MemoryParser<E[]> parser() {
             return segment -> (E[])IntStream.range(0, length).mapToObj(i ->
-                    memberType.parseMemory(segment.asSlice(i * memberType.size()))).toArray();
+                    memberType.parseMemory(segment.asSlice(i * memberType.sizePadded()))).toArray();
         }
 
         @Override

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/BloomFilterMapTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/BloomFilterMapTest.java
@@ -1,88 +1,109 @@
 package me.bechberger.ebpf.bpf;
 
+import me.bechberger.ebpf.annotations.Type;
 import me.bechberger.ebpf.annotations.bpf.BPF;
+import me.bechberger.ebpf.annotations.bpf.BPFFunction;
 import me.bechberger.ebpf.annotations.bpf.BPFMapDefinition;
 import me.bechberger.ebpf.bpf.map.BPFBloomFilter;
+import me.bechberger.ebpf.bpf.map.BPFRingBuffer;
+import me.bechberger.ebpf.runtime.PtDefinitions;
 import me.bechberger.ebpf.shared.TraceLog;
+import me.bechberger.ebpf.type.Enum;
+import me.bechberger.ebpf.type.Ptr;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BloomFilterMapTest {
 
+    public static final int PLACED = 12;
+
     @BPF(license = "GPL")
     public static abstract class Program extends BPFProgram {
+        @Type
+        protected enum ResultPoint implements Enum<ResultPoint> {
+            PLACED, BEFORE, AFTER
+        }
+
+        @Type
+        protected record Result(
+                ResultPoint point,
+                boolean ok
+        ) {
+        }
+
+        @BPFMapDefinition(maxEntries = 4)
+        BPFRingBuffer<Result> results;
+
         @BPFMapDefinition(maxEntries = 256)
         BPFBloomFilter<Integer> filter;
 
-        static final String EBPF_PROGRAM = """
-            #include <vmlinux.h>
-            #include <bpf/bpf_helpers.h>
-            #include <bpf/bpf_endian.h>
 
-            SEC ("kprobe/do_sys_openat2")
-                 int kprobe__do_sys_openat2 (struct pt_regs *ctx)
-            {
-              int placed_value = 12;
-              bool placed_value_in_filter = !bpf_map_peek_elem(&filter, &placed_value);
-              if (placed_value_in_filter) {
-                bpf_printk("Placed OK");
-              } else {
-                bpf_printk("Placed NOT OK");
-              }
-
-              int value = 11;
-              bool maybe_in_filter = !bpf_map_peek_elem(&filter, &value);
-              if (!maybe_in_filter) {
-                bpf_printk("Before OK");
-              } else {
-                bpf_printk("Before NOT OK");
-              }
-
-              bpf_map_push_elem(&filter, &value, BPF_ANY);
-              maybe_in_filter = !bpf_map_peek_elem(&filter, &value);
-              if (maybe_in_filter) {
-                bpf_printk("After OK");
-              } else {
-                bpf_printk("After NOT OK");
-              }
-              return 0;
+        @BPFFunction(
+                section = "kprobe/do_sys_openat2",
+                autoAttach = true
+        )
+        int testFilter(Ptr<PtDefinitions.pt_regs> ctx) {
+            int placedValue = PLACED;
+            Ptr<Result> result = results.reserve();
+            if (result != null) {
+                Ptr.of(result.val().point).set(ResultPoint.PLACED);
+                Ptr.of(result.val().ok).set(filter.peek(placedValue));
+                results.submit(result);
             }
-        """;
+
+            int value;
+            for (value = 0; value < 10; value++) {
+                int tmp_value = value;
+                if (!filter.peek(tmp_value)) {
+                    break;
+                }
+            }
+
+            result = results.reserve();
+            if (result != null) {
+                Ptr.of(result.val().point).set(ResultPoint.BEFORE);
+                Ptr.of(result.val().ok).set(!filter.peek(value));
+                results.submit(result);
+            }
+
+            filter.put(value);
+
+            result = results.reserve();
+            if (result != null) {
+                Ptr.of(result.val().point).set(ResultPoint.AFTER);
+                Ptr.of(result.val().ok).set(filter.peek(value));
+                results.submit(result);
+            }
+
+            return 0;
+        }
     }
 
     @Test
-    public void testBasicBloomFilter() throws InterruptedException {
+    public void testBasicBloomFilter() {
         try (var program = BPFProgram.load(BloomFilterMapTest.Program.class)) {
+            program.autoAttachPrograms();
             var filter = program.filter;
-            filter.put(12);
-            program.autoAttachProgram(program.getProgramByName("kprobe__do_sys_openat2"));
+            filter.put(PLACED);
             TestUtil.triggerOpenAt();
 
-            while (true) {
-                var msg = program.readTraceFields().msg();
-                if (msg != null && msg.contains("Placed")) {
-                    assertEquals("Placed OK", msg);
-                    break;
-                }
+            List<Program.Result> results = new ArrayList<>();
+
+            program.results.setCallback(result -> {
+                results.add(result);
+            });
+
+            while (results.size() < 3) {
+                program.results.consumeAndThrow();
             }
 
-            while (true) {
-                var msg = program.readTraceFields().msg();
-                if (msg != null && msg.contains("Before")) {
-                    assertEquals("Before OK", msg);
-                    break;
-                }
-            }
-
-            while (true) {
-                var msg = program.readTraceFields().msg();
-                if (msg != null && msg.contains("After")) {
-                    assertEquals("After OK", msg);
-                    break;
-                }
+            for (var result : results) {
+                assertTrue(result.ok, result.toString());
             }
         }
         TraceLog.getInstance().readAllAvailableLines(Duration.ofMillis(100));

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/DataTypeTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/DataTypeTest.java
@@ -100,7 +100,6 @@ public class DataTypeTest {
             while (program.result.get() == RecordArrayProgram.Result.UNKNOWN) {
             }
             assertEquals(RecordArrayProgram.Result.CORRECT, program.result.get());
-            TraceLog.getInstance().readAllAvailableLines(Duration.ofMillis(100));
         }
     }
 

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/DataTypeTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/DataTypeTest.java
@@ -117,7 +117,6 @@ public class DataTypeTest {
             while (program.result.get() == RecordArrayProgram.Result.UNKNOWN) {
             }
             assertEquals(RecordArrayProgram.Result.CORRECT, program.result.get());
-            TraceLog.getInstance().readAllAvailableLines(Duration.ofMillis(100));
         }
     }
 }

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
@@ -1,13 +1,22 @@
 package me.bechberger.ebpf.bpf;
 
+import me.bechberger.ebpf.annotations.Size;
 import me.bechberger.ebpf.annotations.bpf.BPF;
+import me.bechberger.ebpf.annotations.bpf.BPFFunction;
+import me.bechberger.ebpf.annotations.bpf.BPFMapDefinition;
+import me.bechberger.ebpf.bpf.map.BPFRingBuffer;
+import me.bechberger.ebpf.runtime.OpenDefinitions;
 import me.bechberger.ebpf.shared.TraceLog;
+import me.bechberger.ebpf.type.Ptr;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
+import static me.bechberger.ebpf.bpf.BPFJ.bpf_probe_read_user_str;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -22,38 +31,35 @@ public class FEntryExitAutoAttachTest {
     public static abstract class OpenAt extends BPFProgram {
 
         final GlobalVariable<Integer> targetPid = new GlobalVariable<>(0);
+
         private static final String SYS_PREFIX = "/sys/";
+
+        @BPFMapDefinition(maxEntries = 1024)
+        BPFRingBuffer<@Size(64) String> pathBuffer;
+
+        @BPFFunction(
+                section = "fentry/do_sys_openat2",
+                headerTemplate = "int BPF_PROG($name, $params)",
+                autoAttach = true
+        )
+        int doOpenat2(long dfd, String name, Ptr<OpenDefinitions.open_how> how) {
+            String path = pathBuffer.reserve().asString();
+            if (path == null) {
+                return 0;
+            }
+            bpf_probe_read_user_str(path, 64, name);
+            pathBuffer.submit(Ptr.of(path).<String>cast());
+            return 0;
+        }
 
         static final String EBPF_PROGRAM = """
                 #include "vmlinux.h"
                 #include <bpf/bpf_helpers.h>
                 #include <bpf/bpf_tracing.h>
                 
-                SEC("fentry/do_sys_openat2")
-                int BPF_PROG(do_openat2, long dfd, const u8* name, struct open_how *how)
-                {
-                	char name_copy[sizeof(SYS_PREFIX)];
-                	BPF_SNPRINTF(name_copy, sizeof(name_copy), "%s", name);
-                	bool is_sys = bpf_strncmp(name_copy, sizeof(SYS_PREFIX), (const u8*) SYS_PREFIX) == 0;
-                	pid_t pid;
-                	pid = bpf_get_current_pid_tgid() >> 32;
-                	if (pid == targetPid && !is_sys) {
-                	    bpf_printk("fentry: pid = %d, filename = %s", pid, name);
-                	}
-                	return 0;
-                }
-                
                 SEC("fexit/do_sys_openat2")
                 int BPF_PROG(do_openat2_exit, long dfd, const char *name, struct open_how *how, long ret)
                 {
-                	char name_copy[sizeof(SYS_PREFIX)];
-                	BPF_SNPRINTF(name_copy, sizeof(name_copy), "%s", name);
-                	bool is_sys = bpf_strncmp(name_copy, sizeof(SYS_PREFIX), (const u8*) SYS_PREFIX) == 0;
-                	pid_t pid;
-                	pid = bpf_get_current_pid_tgid() >> 32;
-                	if (pid == targetPid && !is_sys) {
-                	    bpf_printk("fexit: pid = %d, filename = %s", pid, name);
-                	}
                 	return 0;
                 }
                 
@@ -67,26 +73,30 @@ public class FEntryExitAutoAttachTest {
 
     @Test
     public void testOpenAt() throws IOException {
-        Path testFile;
+        Path testFile = Path.of("");
+        List<String> files = new ArrayList<>();
         try (var program = BPFProgram.load(OpenAt.class)) {
             program.autoAttachPrograms();
             program.targetPid.set((int) ProcessHandle.current().pid());
+            program.pathBuffer.setCallback(path -> {
+                files.add(path);
+            });
             testFile = TestUtil.triggerOpenAt();
+            try {
+                program.pathBuffer.consume();
+            } catch (Exception e) {
+                // Ignore
+            }
+            assertTrue(files.contains(testFile.toString()));
         }
-        var entryLine = TraceLog.getInstance().readLine();
-        assertTrue(entryLine.contains("fentry"), entryLine);
-        assertTrue(entryLine.contains(testFile.toString()), entryLine);
-        var exitLine = TraceLog.getInstance().readLine();
-        assertTrue(exitLine.contains("fexit"), exitLine);
-        assertTrue(exitLine.contains(testFile.toString()), exitLine);
 
-        var line = TraceLog.getInstance().readAllAvailableLines();
+        TraceLog.getInstance().readAllAvailableLines();
     }
 
     @Test
     public void testAutoAttachAll() {
         try (var program = BPFProgram.load(OpenAt.class)) {
-            assertEquals(List.of("do_openat2", "do_openat2_exit", "kprobe__do_sys_openat2"), program.getAutoAttachablePrograms());
+            assertEquals(Stream.of("doOpenat2", "do_openat2_exit", "kprobe__do_sys_openat2").sorted().toList(), program.getAllAutoAttachablePrograms().stream().sorted().toList());
         }
     }
 }

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/FEntryExitAutoAttachTest.java
@@ -89,8 +89,6 @@ public class FEntryExitAutoAttachTest {
             }
             assertTrue(files.contains(testFile.toString()));
         }
-
-        TraceLog.getInstance().readAllAvailableLines();
     }
 
     @Test


### PR DESCRIPTION
As mentioned in #42, this changes tests to use ring buffers and global variables instead of `bpf_printk`. Where this is done, the inline string c programs are converted to java.