### PR TITLE
Support more program types

### DIFF
--- a/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPF.java
+++ b/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPF.java
@@ -42,6 +42,7 @@ public @interface BPF {
             "vmlinux.h",
             "bpf/bpf_helpers.h",
             "bpf/bpf_endian.h",
-            "bpf/bpf_tracing.h"
+            "bpf/bpf_tracing.h",
+            "bpf/bpf_core_read.h"
     };
 }

--- a/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPFFunction.java
+++ b/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPFFunction.java
@@ -76,5 +76,5 @@ public @interface BPFFunction {
 
     boolean addDefinition() default true;
 
-    Set<String> autoAttachableSections = Set.of("fentry", "fexit", "kprobe", "kretprobe");
+    Set<String> autoAttachableSections = Set.of("fentry", "fexit", "kprobe", "kretprobe", "ksyscall");
 }

--- a/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPFFunction.java
+++ b/annotations/src/main/java/me/bechberger/ebpf/annotations/bpf/BPFFunction.java
@@ -76,5 +76,5 @@ public @interface BPFFunction {
 
     boolean addDefinition() default true;
 
-    Set<String> autoAttachableSections = Set.of("fentry", "fexit", "kprobe", "kretprobe", "ksyscall");
+    Set<String> autoAttachableSections = Set.of("fentry", "fexit", "kprobe", "kretprobe", "ksyscall", "tp");
 }

--- a/bpf/src/main/java/me/bechberger/ebpf/bpf/BPFProgram.java
+++ b/bpf/src/main/java/me/bechberger/ebpf/bpf/BPFProgram.java
@@ -531,6 +531,29 @@ public abstract class BPFProgram implements AutoCloseable {
         }
     }
 
+    private static final HandlerWithErrno<MemorySegment> BPF_PROGRAM__ATTACH_TRACEPOINT =
+            new HandlerWithErrno<>("bpf_program__attach_tracepoint",
+                    FunctionDescriptor.of(PanamaUtil.POINTER, PanamaUtil.POINTER, PanamaUtil.POINTER));
+
+    public BPFLink tracepointAttach(String programName, String tracepoint) {
+        return tracepointAttach(getProgramByName(programName), tracepoint);
+    }
+
+    public BPFLink tracepointAttach(ProgramHandle prog, String tracepoint) {
+        try (var arena = Arena.ofConfined()) {
+            var ret = BPF_PROGRAM__ATTACH_TRACEPOINT.call(prog.prog(), arena.allocateFrom(tracepoint));
+            if (ret.result() == MemorySegment.NULL) {
+                throw new BPFAttachError(prog.name, ret.err());
+            }
+            var link = new BPFLink(ret.result());
+            if (link.segment.address() == 0) {
+                throw new BPFAttachError(prog.name, ret.err());
+            }
+            attachedPrograms.add(link);
+            return link;
+        }
+    }
+
     public void xdpAttach(ProgramHandle prog, List<Integer> ifindex) {
         for (var index : ifindex) {
             xdpAttach(prog, index);

--- a/bpf/src/test/java/me/bechberger/ebpf/bpf/TracepointAttachTest.java
+++ b/bpf/src/test/java/me/bechberger/ebpf/bpf/TracepointAttachTest.java
@@ -1,0 +1,67 @@
+package me.bechberger.ebpf.bpf;
+
+import me.bechberger.ebpf.annotations.Type;
+import me.bechberger.ebpf.annotations.Unsigned;
+import me.bechberger.ebpf.annotations.bpf.BPF;
+import me.bechberger.ebpf.annotations.bpf.BPFFunction;
+import me.bechberger.ebpf.runtime.OpenDefinitions;
+import me.bechberger.ebpf.type.Ptr;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for ksyscall attachment
+ */
+public class TracepointAttachTest {
+
+    @BPF(license = "GPL")
+    public static abstract class OpenAt extends BPFProgram {
+
+        final GlobalVariable<Boolean> ksyscallTriggered = new GlobalVariable<>(false);
+        @Type
+        record OpenAt2Ctx(
+                SyscallCtx syscall,
+                OpenAt2Args openAt
+        ) {
+        }
+
+        @Type
+        record SyscallCtx(
+                @Unsigned short common_type,
+                byte common_flags,
+                byte common_preempt_count,
+                int common_pid,
+                int __syscall_nr
+        ) {
+        }
+
+        @Type
+        record OpenAt2Args(@Unsigned int dfd, Ptr<Byte> filename, Ptr<OpenDefinitions.open_how> how, @Unsigned long usize) {
+        }
+
+        @BPFFunction(
+                headerTemplate = "int $name($params)",
+                section = "tp/syscalls/sys_enter_openat",
+                autoAttach = true
+        )
+        int syscall_openat2(Ptr<OpenAt2Ctx> ctx) {
+            ksyscallTriggered.set(true);
+            return 0;
+        }
+    }
+
+
+    @Test
+    public void testOpenAt() {
+        List<String> files = new ArrayList<>();
+        try (var program = BPFProgram.load(OpenAt.class)) {
+            program.autoAttachPrograms();
+            TestUtil.triggerOpenAt();
+            assertTrue(program.ksyscallTriggered.get());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the [`ksyscall`](https://docs.ebpf.io/ebpf-library/libbpf/ebpf/BPF_KSYSCALL/) libbpf macro by allowing the auto-attachment of `ksyscall` programs and adding `bpf/bpf_core_read.h` to the default includes because it is needed for expansion of `BPF_KSYSCALL`.
It also adds a method for attaching programs with the `tracepoint` program type and allows of auto-attach of them.