### PR TITLE
Translate `return;` to `return 0;`

### DIFF
--- a/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/Translator.java
+++ b/bpf-compiler-plugin/src/main/java/me/bechberger/ebpf/bpf/compiler/Translator.java
@@ -274,9 +274,9 @@ class Translator {
     }
 
     @Nullable
-    CAST.Statement.ReturnStatement translate(ReturnTree returnTree) {
-        if (returnTree.getExpression() == null) {
-            return new ReturnStatement(null);
+    CAST.Statement.Statement translate(ReturnTree returnTree) {
+        if (returnTree.getExpression() == null) { // Since void functions aren't allowed, returns without an argument don't make sense
+            return new VerbatimStatement("return 0;");
         }
         return callIfNonNull(translate(returnTree.getExpression()), ReturnStatement::new);
     }


### PR DESCRIPTION
Since the compiler plugin translates methods returning `void` to `int` functions in C, it should also translate returns without a value to returns with an int.