### PR TITLE
Don't search for clang in static initializer

### DIFF
--- a/bpf-processor/src/main/java/me/bechberger/ebpf/bpf/processor/Processor.java
+++ b/bpf-processor/src/main/java/me/bechberger/ebpf/bpf/processor/Processor.java
@@ -516,7 +516,6 @@ public class Processor extends AbstractProcessor {
         throw new RuntimeException("Could not find clang >= 19");
     }
 
-    private static final String newestClang = findNewestClangVersion();
     private static Path includePath;
 
     /** Find the library include path */
@@ -568,7 +567,7 @@ public class Processor extends AbstractProcessor {
         try {
             var tempFile = Files.createTempFile("ebpf", ".o");
             tempFile.toFile().deleteOnExit();
-            List<String> command = List.of(newestClang, "-O2", "-g", "-std=gnu2y",  "-target", "bpf", "-c", "-o",
+            List<String> command = List.of(findNewestClangVersion(), "-O2", "-g", "-std=gnu2y",  "-target", "bpf", "-c", "-o",
                     tempFile.toString(), "-I", vmlinuxHeader.getParent().toString(),
                     "-D__TARGET_ARCH_" + getArch(), "-Wno-parentheses-equality", "-Wno-unused-value", "-Wreturn-type",
                     "-Wno-incompatible-pointer-types-discards-qualifiers",


### PR DESCRIPTION
Looks like graal behaved correctly. Because `BPFProgram::getImplClass` uses `Processor::classToImplName`, the `Processor` class is loaded at runtime, resulting in a failure if no clang >= 19 is found.